### PR TITLE
Add user registration with Argon2id password hashing

### DIFF
--- a/services/auth-service/migrations/20240101000001_create_users_table.sql
+++ b/services/auth-service/migrations/20240101000001_create_users_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    username VARCHAR(50) NOT NULL UNIQUE,
+    display_name VARCHAR(100) NOT NULL,
+    password_hash TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/services/auth-service/src/app.rs
+++ b/services/auth-service/src/app.rs
@@ -1,12 +1,13 @@
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::Router;
 use sqlx::PgPool;
 
-use crate::routes::health;
+use crate::routes::{auth, health};
 
 pub fn create_router(pool: PgPool) -> Router {
     Router::new()
         .route("/healthz", get(health::healthz))
         .route("/readyz", get(health::readyz))
+        .route("/auth/register", post(auth::register))
         .with_state(pool)
 }

--- a/services/auth-service/src/errors.rs
+++ b/services/auth-service/src/errors.rs
@@ -9,13 +9,25 @@ pub enum AppError {
 
     #[error("internal error: {0}")]
     Internal(String),
+
+    #[error("conflict: {0}")]
+    Conflict(String),
+
+    #[error("validation error: {0}")]
+    Validation(String),
+
+    #[error("unauthorized")]
+    Unauthorized,
 }
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let (status, message) = match &self {
-            AppError::Database(_) => (StatusCode::INTERNAL_SERVER_ERROR, "internal server error"),
-            AppError::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, "internal server error"),
+            AppError::Database(_) => (StatusCode::INTERNAL_SERVER_ERROR, "internal server error".to_string()),
+            AppError::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, "internal server error".to_string()),
+            AppError::Conflict(msg) => (StatusCode::CONFLICT, msg.clone()),
+            AppError::Validation(msg) => (StatusCode::UNPROCESSABLE_ENTITY, msg.clone()),
+            AppError::Unauthorized => (StatusCode::UNAUTHORIZED, "unauthorized".to_string()),
         };
 
         tracing::error!(%status, error = %self, "request error");

--- a/services/auth-service/src/lib.rs
+++ b/services/auth-service/src/lib.rs
@@ -2,4 +2,6 @@ pub mod app;
 pub mod config;
 pub mod db;
 pub mod errors;
+pub mod models;
 pub mod routes;
+pub mod services;

--- a/services/auth-service/src/models/mod.rs
+++ b/services/auth-service/src/models/mod.rs
@@ -1,0 +1,1 @@
+pub mod user;

--- a/services/auth-service/src/models/user.rs
+++ b/services/auth-service/src/models/user.rs
@@ -1,0 +1,122 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, sqlx::FromRow)]
+pub struct User {
+    pub id: Uuid,
+    pub username: String,
+    pub display_name: String,
+    pub password_hash: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateUserRequest {
+    pub username: String,
+    pub display_name: String,
+    pub password: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UserResponse {
+    pub id: Uuid,
+    pub username: String,
+    pub display_name: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl From<User> for UserResponse {
+    fn from(user: User) -> Self {
+        Self {
+            id: user.id,
+            username: user.username,
+            display_name: user.display_name,
+            created_at: user.created_at,
+        }
+    }
+}
+
+impl CreateUserRequest {
+    pub fn validate(&self) -> Result<(), Vec<String>> {
+        let mut errors = Vec::new();
+
+        if self.username.len() < 3 || self.username.len() > 50 {
+            errors.push("username must be between 3 and 50 characters".to_string());
+        }
+
+        if self.display_name.is_empty() || self.display_name.len() > 100 {
+            errors.push("display_name must be between 1 and 100 characters".to_string());
+        }
+
+        if self.password.len() < 8 || self.password.len() > 128 {
+            errors.push("password must be between 8 and 128 characters".to_string());
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_request_passes_validation() {
+        let req = CreateUserRequest {
+            username: "testuser".to_string(),
+            display_name: "Test User".to_string(),
+            password: "password123".to_string(),
+        };
+        assert!(req.validate().is_ok());
+    }
+
+    #[test]
+    fn short_username_fails_validation() {
+        let req = CreateUserRequest {
+            username: "ab".to_string(),
+            display_name: "Test".to_string(),
+            password: "password123".to_string(),
+        };
+        let errors = req.validate().unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("username")));
+    }
+
+    #[test]
+    fn empty_display_name_fails_validation() {
+        let req = CreateUserRequest {
+            username: "testuser".to_string(),
+            display_name: "".to_string(),
+            password: "password123".to_string(),
+        };
+        let errors = req.validate().unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("display_name")));
+    }
+
+    #[test]
+    fn short_password_fails_validation() {
+        let req = CreateUserRequest {
+            username: "testuser".to_string(),
+            display_name: "Test".to_string(),
+            password: "short".to_string(),
+        };
+        let errors = req.validate().unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("password")));
+    }
+
+    #[test]
+    fn multiple_validation_errors_returned() {
+        let req = CreateUserRequest {
+            username: "a".to_string(),
+            display_name: "".to_string(),
+            password: "short".to_string(),
+        };
+        let errors = req.validate().unwrap_err();
+        assert_eq!(errors.len(), 3);
+    }
+}

--- a/services/auth-service/src/routes/auth.rs
+++ b/services/auth-service/src/routes/auth.rs
@@ -1,0 +1,37 @@
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use sqlx::PgPool;
+
+use crate::errors::AppError;
+use crate::models::user::{CreateUserRequest, UserResponse};
+use crate::services::password::hash_password;
+
+pub async fn register(
+    State(pool): State<PgPool>,
+    Json(req): Json<CreateUserRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    req.validate()
+        .map_err(|errors| AppError::Validation(errors.join("; ")))?;
+
+    let password_hash =
+        hash_password(&req.password).map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let user = sqlx::query_as::<_, crate::models::user::User>(
+        "INSERT INTO users (username, display_name, password_hash) VALUES ($1, $2, $3) RETURNING *",
+    )
+    .bind(&req.username)
+    .bind(&req.display_name)
+    .bind(&password_hash)
+    .fetch_one(&pool)
+    .await
+    .map_err(|e| match &e {
+        sqlx::Error::Database(db_err) if db_err.constraint() == Some("users_username_key") => {
+            AppError::Conflict("username already taken".to_string())
+        }
+        _ => AppError::Database(e),
+    })?;
+
+    Ok((StatusCode::CREATED, Json(UserResponse::from(user))))
+}

--- a/services/auth-service/src/routes/mod.rs
+++ b/services/auth-service/src/routes/mod.rs
@@ -1,1 +1,2 @@
+pub mod auth;
 pub mod health;

--- a/services/auth-service/src/services/mod.rs
+++ b/services/auth-service/src/services/mod.rs
@@ -1,0 +1,1 @@
+pub mod password;

--- a/services/auth-service/src/services/password.rs
+++ b/services/auth-service/src/services/password.rs
@@ -1,0 +1,58 @@
+use argon2::{
+    password_hash::{rand_core::OsRng, SaltString},
+    Argon2, PasswordHash, PasswordHasher, PasswordVerifier,
+};
+
+pub fn hash_password(password: &str) -> Result<String, argon2::password_hash::Error> {
+    let salt = SaltString::generate(&mut OsRng);
+    let argon2 = Argon2::default();
+    let hash = argon2.hash_password(password.as_bytes(), &salt)?;
+    Ok(hash.to_string())
+}
+
+pub fn verify_password(password: &str, hash: &str) -> Result<bool, argon2::password_hash::Error> {
+    let parsed_hash = PasswordHash::new(hash)?;
+    Ok(Argon2::default()
+        .verify_password(password.as_bytes(), &parsed_hash)
+        .is_ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_produces_argon2id_hash() {
+        let hash = hash_password("testpassword").unwrap();
+        assert!(hash.starts_with("$argon2id$"));
+    }
+
+    #[test]
+    fn verify_correct_password() {
+        let hash = hash_password("mypassword").unwrap();
+        assert!(verify_password("mypassword", &hash).unwrap());
+    }
+
+    #[test]
+    fn verify_wrong_password() {
+        let hash = hash_password("mypassword").unwrap();
+        assert!(!verify_password("wrongpassword", &hash).unwrap());
+    }
+
+    #[test]
+    fn different_passwords_produce_different_hashes() {
+        let hash1 = hash_password("password1").unwrap();
+        let hash2 = hash_password("password2").unwrap();
+        assert_ne!(hash1, hash2);
+    }
+
+    #[test]
+    fn same_password_produces_different_hashes_due_to_salt() {
+        let hash1 = hash_password("samepassword").unwrap();
+        let hash2 = hash_password("samepassword").unwrap();
+        assert_ne!(hash1, hash2);
+        // But both should verify
+        assert!(verify_password("samepassword", &hash1).unwrap());
+        assert!(verify_password("samepassword", &hash2).unwrap());
+    }
+}

--- a/services/auth-service/tests/registration.rs
+++ b/services/auth-service/tests/registration.rs
@@ -1,0 +1,170 @@
+mod common;
+
+use common::spawn_app;
+use serde_json::json;
+use uuid::Uuid;
+
+fn unique(prefix: &str) -> String {
+    format!("{}_{}", prefix, &Uuid::new_v4().to_string()[..8])
+}
+
+#[tokio::test]
+async fn register_with_valid_data_returns_201_and_user_profile() {
+    let app = spawn_app().await;
+    let username = unique("newuser");
+
+    let response = app
+        .client
+        .post(app.url("/auth/register"))
+        .json(&json!({
+            "username": username,
+            "display_name": "New User",
+            "password": "securepassword123"
+        }))
+        .send()
+        .await
+        .expect("Failed to send request");
+
+    assert_eq!(response.status(), 201);
+
+    let body: serde_json::Value = response.json().await.expect("Failed to parse JSON");
+    assert_eq!(body["username"], username);
+    assert_eq!(body["display_name"], "New User");
+    assert!(body["id"].is_string());
+    assert!(body["created_at"].is_string());
+    // password_hash must not be exposed
+    assert!(body.get("password_hash").is_none());
+}
+
+#[tokio::test]
+async fn register_duplicate_username_returns_409() {
+    let app = spawn_app().await;
+    let username = unique("dupeuser");
+
+    let payload = json!({
+        "username": username,
+        "display_name": "First User",
+        "password": "securepassword123"
+    });
+
+    // Register first user
+    let response = app
+        .client
+        .post(app.url("/auth/register"))
+        .json(&payload)
+        .send()
+        .await
+        .expect("Failed to send request");
+    assert_eq!(response.status(), 201);
+
+    // Register duplicate
+    let response = app
+        .client
+        .post(app.url("/auth/register"))
+        .json(&json!({
+            "username": username,
+            "display_name": "Second User",
+            "password": "anotherpassword123"
+        }))
+        .send()
+        .await
+        .expect("Failed to send request");
+    assert_eq!(response.status(), 409);
+}
+
+#[tokio::test]
+async fn register_with_invalid_fields_returns_422() {
+    let app = spawn_app().await;
+
+    // Short username
+    let response = app
+        .client
+        .post(app.url("/auth/register"))
+        .json(&json!({
+            "username": "ab",
+            "display_name": "Test",
+            "password": "securepassword123"
+        }))
+        .send()
+        .await
+        .expect("Failed to send request");
+    assert_eq!(response.status(), 422);
+
+    // Short password
+    let response = app
+        .client
+        .post(app.url("/auth/register"))
+        .json(&json!({
+            "username": "validuser",
+            "display_name": "Test",
+            "password": "short"
+        }))
+        .send()
+        .await
+        .expect("Failed to send request");
+    assert_eq!(response.status(), 422);
+
+    // Empty display name
+    let response = app
+        .client
+        .post(app.url("/auth/register"))
+        .json(&json!({
+            "username": "validuser2",
+            "display_name": "",
+            "password": "securepassword123"
+        }))
+        .send()
+        .await
+        .expect("Failed to send request");
+    assert_eq!(response.status(), 422);
+}
+
+#[tokio::test]
+async fn register_stores_password_as_argon2id_hash() {
+    let app = spawn_app().await;
+    let username = unique("hashcheck");
+
+    let response = app
+        .client
+        .post(app.url("/auth/register"))
+        .json(&json!({
+            "username": username,
+            "display_name": "Hash Check",
+            "password": "mypassword123"
+        }))
+        .send()
+        .await
+        .expect("Failed to send request");
+    assert_eq!(response.status(), 201);
+
+    // Verify the hash in the database is Argon2id
+    let row: (String,) = sqlx::query_as("SELECT password_hash FROM users WHERE username = $1")
+        .bind(&username)
+        .fetch_one(&app.pool)
+        .await
+        .expect("Failed to query user");
+
+    assert!(
+        row.0.starts_with("$argon2id$"),
+        "Password hash should be Argon2id, got: {}",
+        &row.0[..20]
+    );
+}
+
+#[tokio::test]
+async fn register_with_missing_fields_returns_422() {
+    let app = spawn_app().await;
+
+    // Missing password field entirely
+    let response = app
+        .client
+        .post(app.url("/auth/register"))
+        .json(&json!({
+            "username": "testuser",
+            "display_name": "Test"
+        }))
+        .send()
+        .await
+        .expect("Failed to send request");
+    assert_eq!(response.status(), 422);
+}

--- a/services/auth-service/tests/registration.rs
+++ b/services/auth-service/tests/registration.rs
@@ -41,23 +41,22 @@ async fn register_duplicate_username_returns_409() {
     let app = spawn_app().await;
     let username = unique("dupeuser");
 
-    let payload = json!({
-        "username": username,
-        "display_name": "First User",
-        "password": "securepassword123"
-    });
-
-    // Register first user
+    // Register first user — .expect() panics only if the HTTP request
+    // fails to send (network error), not on a non-200 status code.
     let response = app
         .client
         .post(app.url("/auth/register"))
-        .json(&payload)
+        .json(&json!({
+            "username": username,
+            "display_name": "First User",
+            "password": "securepassword123"
+        }))
         .send()
         .await
         .expect("Failed to send request");
     assert_eq!(response.status(), 201);
 
-    // Register duplicate
+    // Register same username again
     let response = app
         .client
         .post(app.url("/auth/register"))


### PR DESCRIPTION
## Summary
- Adds `POST /auth/register` endpoint with input validation and Argon2id password hashing
- Creates `auth.users` table migration (id, username, display_name, password_hash, timestamps)
- Duplicate username returns 409, validation failures return 422
- Password stored as Argon2id hash, never exposed in API responses
- Extends `AppError` with `Conflict`, `Validation`, and `Unauthorized` variants

## BDD tests (5 integration tests)
- Valid registration returns 201 + user profile (no password_hash)
- Duplicate username returns 409
- Invalid fields (short username/password, empty display_name) return 422
- Missing required fields return 422
- Password stored in DB is Argon2id hash (verified by direct DB query)

## TDD unit tests (10 unit tests)
- `CreateUserRequest` validation: valid input, short username, empty display_name, short password, multiple errors
- Argon2id: produces `$argon2id$` prefix, correct password verifies, wrong password rejects, different passwords differ, same password gets different salts

## Test plan
- [x] `cargo test` — all 19 tests pass (11 unit + 8 integration)
- [x] Manual: `curl -X POST http://localhost:8081/auth/register -H 'Content-Type: application/json' -d '{"username":"test","password":"testpass1","display_name":"Test"}'`

## Process note
Honest disclosure: the BDD tests and implementation were written together rather than in strict Red-Green-Refactor order. The tests are valid behavioral tests, but the TDD discipline was not followed for this PR. PRs 3 and 4 will follow the cycle correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)